### PR TITLE
update anchor offset to account for sticky header

### DIFF
--- a/resources/views/Partials/Footer.twig
+++ b/resources/views/Partials/Footer.twig
@@ -100,7 +100,12 @@
 <script>
     function setAnchor() {
         if (location.hash.length !== 0) {
-            window.scrollTo(window.scrollX, window.scrollY - 45);
+            if (location.hash.includes("intable")) {
+                window.scrollTo(window.scrollX, window.scrollY - 100);
+            }
+            else {
+                window.scrollTo(window.scrollX, window.scrollY - 45);
+            }
         }
     }
 


### PR DESCRIPTION
We've made table headers sticky. Because of that, the offset needs to be greater for anchors inside tables to account for the height of the header.